### PR TITLE
👷 [Vitest] Default to `happy-dom` environment

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,3 @@
-export type {SetIntervalId} from './types';
-
 export * from './useInterval';
 export * from './useIsoLayoutEffect';
 export * from './useTimeout';

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-export type {SetIntervalId, SetTimeoutId} from './types';
+export type {SetIntervalId} from './types';
 
 export * from './useInterval';
 export * from './useIsoLayoutEffect';

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,5 @@
+export type {SetIntervalId, SetTimeoutId} from './types';
+
 export * from './useInterval';
 export * from './useIsoLayoutEffect';
 export * from './useTimeout';

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,6 @@
 export interface BasicObject {
   [key: string]: unknown;
 }
+
+export type SetIntervalId = number | ReturnType<typeof setInterval>;
+export type SetTimeoutId = number | ReturnType<typeof setTimeout>;

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,3 @@
 export interface BasicObject {
   [key: string]: unknown;
 }
-
-export type SetIntervalId = ReturnType<typeof setInterval>;

--- a/src/types.ts
+++ b/src/types.ts
@@ -3,4 +3,3 @@ export interface BasicObject {
 }
 
 export type SetIntervalId = ReturnType<typeof setInterval>;
-export type SetTimeoutId = ReturnType<typeof setTimeout>;

--- a/src/useInterval/tests/utilities.test.ts
+++ b/src/useInterval/tests/utilities.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import {getDelay} from '../utilities';
 import type {DelayFnArgs} from '../types';
 

--- a/src/useInterval/useInterval.ts
+++ b/src/useInterval/useInterval.ts
@@ -1,12 +1,14 @@
 import {useCallback, useEffect, useRef} from 'react';
 
-import type {SetIntervalId, SetTimeoutId} from '../types';
+import type {SetIntervalId} from '../types';
 import type {
   IntervalCallback,
   IntervalHookOptions,
   IntervalTimeData,
 } from './types';
 import {getDelay} from './utilities';
+
+export type SetTimeoutId = ReturnType<typeof setTimeout>;
 
 const DEFAULT_OPTIONS: Required<IntervalHookOptions> = {
   duration: 0,

--- a/src/useInterval/useInterval.ts
+++ b/src/useInterval/useInterval.ts
@@ -1,5 +1,6 @@
 import {useCallback, useEffect, useRef} from 'react';
 
+import type {SetIntervalId, SetTimeoutId} from '../types';
 import type {
   IntervalCallback,
   IntervalHookOptions,
@@ -29,8 +30,8 @@ export function useInterval(
   };
 
   const callbackRef = useRef<IntervalCallback>();
-  const intervalRef = useRef<number>();
-  const timeoutRef = useRef<number>();
+  const intervalRef = useRef<SetIntervalId>();
+  const timeoutRef = useRef<SetTimeoutId>();
 
   const firstIntervalPlayed = useRef(false);
 
@@ -86,14 +87,14 @@ export function useInterval(
       });
 
       // TODO: Should we use the `useTimeout()` hook instead?
-      timeoutRef.current = window.setTimeout(() => {
+      timeoutRef.current = setTimeout(() => {
         handleCallback();
 
         if (!firstIntervalPlayed.current) {
           firstIntervalPlayed.current = true;
         }
 
-        intervalRef.current = window.setInterval(handleCallback, duration);
+        intervalRef.current = setInterval(handleCallback, duration);
       }, delay);
     }
 
@@ -112,8 +113,9 @@ export function useInterval(
     }
 
     return () => {
-      window.clearInterval(intervalRef.current);
-      window.clearTimeout(timeoutRef.current);
+      // TODO: Unfortunate typecasting because of dual DOM/Node environment.
+      clearInterval(intervalRef.current as unknown as number);
+      clearTimeout(timeoutRef.current as unknown as number);
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [duration, playing, allowPausing]);

--- a/src/useInterval/useInterval.ts
+++ b/src/useInterval/useInterval.ts
@@ -1,14 +1,11 @@
 import {useCallback, useEffect, useRef} from 'react';
 
-import type {SetIntervalId} from '../types';
 import type {
   IntervalCallback,
   IntervalHookOptions,
   IntervalTimeData,
 } from './types';
 import {getDelay} from './utilities';
-
-export type SetTimeoutId = ReturnType<typeof setTimeout>;
 
 const DEFAULT_OPTIONS: Required<IntervalHookOptions> = {
   duration: 0,
@@ -32,8 +29,8 @@ export function useInterval(
   };
 
   const callbackRef = useRef<IntervalCallback>();
-  const intervalRef = useRef<SetIntervalId>();
-  const timeoutRef = useRef<SetTimeoutId>();
+  const intervalRef = useRef<number>();
+  const timeoutRef = useRef<number>();
 
   const firstIntervalPlayed = useRef(false);
 
@@ -89,14 +86,14 @@ export function useInterval(
       });
 
       // TODO: Should we use the `useTimeout()` hook instead?
-      timeoutRef.current = setTimeout(() => {
+      timeoutRef.current = window.setTimeout(() => {
         handleCallback();
 
         if (!firstIntervalPlayed.current) {
           firstIntervalPlayed.current = true;
         }
 
-        intervalRef.current = setInterval(handleCallback, duration);
+        intervalRef.current = window.setInterval(handleCallback, duration);
       }, delay);
     }
 
@@ -115,9 +112,8 @@ export function useInterval(
     }
 
     return () => {
-      // TODO: Really stupid casting required by TypeScript
-      clearInterval(intervalRef.current as unknown as number);
-      clearTimeout(timeoutRef.current as unknown as number);
+      window.clearInterval(intervalRef.current);
+      window.clearTimeout(timeoutRef.current);
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [duration, playing, allowPausing]);

--- a/src/useIsoLayoutEffect/tests/client.test.ts
+++ b/src/useIsoLayoutEffect/tests/client.test.ts
@@ -1,4 +1,3 @@
-// @vitest-environment happy-dom
 import {useIsoLayoutEffect} from '../useIsoLayoutEffect';
 
 describe('useIsoLayoutEffect > client', () => {

--- a/src/useIsoLayoutEffect/tests/server.test.ts
+++ b/src/useIsoLayoutEffect/tests/server.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import {useIsoLayoutEffect} from '../useIsoLayoutEffect';
 
 describe('useIsoLayoutEffect > server side', () => {

--- a/src/useIsoLayoutEffect/tests/useIsoLayoutEffect.test.tsx
+++ b/src/useIsoLayoutEffect/tests/useIsoLayoutEffect.test.tsx
@@ -1,8 +1,7 @@
 import React from 'react';
-import {act, create} from 'react-test-renderer';
+import {act} from 'react-test-renderer';
 
-import {noop} from '../../utilities';
-
+import {mount, noop} from '../../utilities';
 import {IsoComponent} from './IsoComponent';
 
 // This test is somewhat useless... we don't need to test
@@ -21,7 +20,7 @@ describe('useIsoLayoutEffect', () => {
   describe('callback', () => {
     it('executes on mount', () => {
       const mockCallback = vi.fn(noop);
-      create(<IsoComponent callback={mockCallback} />);
+      mount(<IsoComponent callback={mockCallback} />);
 
       vi.advanceTimersByTime(1);
       expect(mockCallback).toHaveBeenCalledOnce();
@@ -29,14 +28,12 @@ describe('useIsoLayoutEffect', () => {
 
     it('executes again after dependency change', () => {
       const mockCallback = vi.fn(noop);
-      const component = create(<IsoComponent callback={mockCallback} />);
+      const wrapper = mount(<IsoComponent callback={mockCallback} />);
 
       vi.advanceTimersByTime(1);
 
       act(() => {
-        component.update(
-          <IsoComponent callback={mockCallback} dependencyProp />,
-        );
+        wrapper.update(<IsoComponent callback={mockCallback} dependencyProp />);
       });
 
       vi.advanceTimersByTime(1);

--- a/src/useTimeout/tests/useTimeout.test.tsx
+++ b/src/useTimeout/tests/useTimeout.test.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
-import {act, create, ReactTestRenderer} from 'react-test-renderer';
+import {act} from 'react-test-renderer';
 import type vitestTypes from 'vitest';
+
+import {mount} from '../../utilities';
 import {TimeoutComponent} from './TimeoutComponent';
 
 describe('useTimeout', () => {
@@ -37,7 +39,7 @@ describe('useTimeout', () => {
     it('does not execute before the timeout has expired', () => {
       const mockCallback = vi.fn((timestamp) => timestamp);
 
-      create(
+      mount(
         <TimeoutComponent callback={mockCallback} duration={mockDuration} />,
       );
 
@@ -49,7 +51,7 @@ describe('useTimeout', () => {
     it('executes after timeout has expired', () => {
       const mockCallback = vi.fn((timestamp) => timestamp);
 
-      create(
+      mount(
         <TimeoutComponent callback={mockCallback} duration={mockDuration} />,
       );
 
@@ -63,7 +65,7 @@ describe('useTimeout', () => {
     it('executes `callback` immediately by default', () => {
       const mockCallback = vi.fn((timestamp) => timestamp);
 
-      create(<TimeoutComponent callback={mockCallback} />);
+      mount(<TimeoutComponent callback={mockCallback} />);
 
       expect(mockCallback).not.toHaveBeenCalled();
       vi.advanceTimersByTime(1);
@@ -73,7 +75,7 @@ describe('useTimeout', () => {
     it('executes `callback` immediately when `0`', () => {
       const mockCallback = vi.fn((timestamp) => timestamp);
 
-      create(<TimeoutComponent callback={mockCallback} duration={0} />);
+      mount(<TimeoutComponent callback={mockCallback} duration={0} />);
 
       expect(mockCallback).not.toHaveBeenCalled();
       vi.advanceTimersByTime(1);
@@ -87,7 +89,7 @@ describe('useTimeout', () => {
     it('does not execute when `false`', () => {
       const mockCallback = vi.fn((timestamp) => timestamp);
 
-      create(
+      mount(
         <TimeoutComponent
           callback={mockCallback}
           duration={mockDuration}
@@ -102,20 +104,15 @@ describe('useTimeout', () => {
 
     it('will prevent `callback` from executing when toggled before expiration', () => {
       const mockCallback = vi.fn((timestamp) => timestamp);
-      let component: ReactTestRenderer;
-
-      act(() => {
-        component = create(
-          <TimeoutComponent callback={mockCallback} duration={mockDuration} />,
-        );
-      });
+      const wrapper = mount(
+        <TimeoutComponent callback={mockCallback} duration={mockDuration} />,
+      );
 
       expect(mockCallback).not.toHaveBeenCalled();
-
       vi.advanceTimersByTime(mockDuration / 2);
 
       act(() => {
-        component.update(
+        wrapper.update(
           <TimeoutComponent
             callback={mockCallback}
             duration={mockDuration}
@@ -125,26 +122,20 @@ describe('useTimeout', () => {
       });
 
       vi.advanceTimersByTime(mockDuration);
-
       expect(mockCallback).not.toHaveBeenCalled();
     });
 
     it('will restart the timeout from the beginning when toggled back and forth', () => {
       const mockCallback = vi.fn((timestamp) => timestamp);
-      let component: ReactTestRenderer;
-
-      act(() => {
-        component = create(
-          <TimeoutComponent callback={mockCallback} duration={mockDuration} />,
-        );
-      });
+      const wrapper = mount(
+        <TimeoutComponent callback={mockCallback} duration={mockDuration} />,
+      );
 
       expect(mockCallback).not.toHaveBeenCalled();
-
       vi.advanceTimersByTime(mockDuration - 1);
 
       act(() => {
-        component.update(
+        wrapper.update(
           <TimeoutComponent
             callback={mockCallback}
             duration={mockDuration}
@@ -154,11 +145,10 @@ describe('useTimeout', () => {
       });
 
       vi.advanceTimersByTime(mockDuration);
-
       expect(mockCallback).not.toHaveBeenCalled();
 
       act(() => {
-        component.update(
+        wrapper.update(
           <TimeoutComponent
             callback={mockCallback}
             duration={mockDuration}

--- a/src/useTimeout/useTimeout.ts
+++ b/src/useTimeout/useTimeout.ts
@@ -1,6 +1,7 @@
 import {useEffect, useRef} from 'react';
 
 import {filterNullishValuesFromObject} from '../utilities';
+import type {SetTimeoutId} from '../types';
 import type {TimeoutCallback, TimeoutHookOptions} from './types';
 
 const DEFAULT_OPTIONS: Required<TimeoutHookOptions> = {
@@ -26,7 +27,7 @@ export function useTimeout(
   };
 
   const callbackRef = useRef<TimeoutCallback>();
-  const timeoutRef = useRef<number>();
+  const timeoutRef = useRef<SetTimeoutId>();
 
   function handleCallback() {
     callbackRef.current?.(Date.now());
@@ -38,9 +39,10 @@ export function useTimeout(
 
   useEffect(() => {
     if (playing) {
-      timeoutRef.current = window.setTimeout(handleCallback, duration);
+      timeoutRef.current = setTimeout(handleCallback, duration);
     }
 
-    return () => window.clearTimeout(timeoutRef.current);
+    // TODO: Unfortunate typecasting because of dual DOM/Node environment.
+    return () => clearTimeout(timeoutRef.current as unknown as number);
   }, [duration, playing]);
 }

--- a/src/useTimeout/useTimeout.ts
+++ b/src/useTimeout/useTimeout.ts
@@ -1,7 +1,6 @@
 import {useEffect, useRef} from 'react';
 
 import {filterNullishValuesFromObject} from '../utilities';
-import type {SetTimeoutId} from '../types';
 import type {TimeoutCallback, TimeoutHookOptions} from './types';
 
 const DEFAULT_OPTIONS: Required<TimeoutHookOptions> = {
@@ -27,7 +26,7 @@ export function useTimeout(
   };
 
   const callbackRef = useRef<TimeoutCallback>();
-  const timeoutRef = useRef<SetTimeoutId>();
+  const timeoutRef = useRef<number>();
 
   function handleCallback() {
     callbackRef.current?.(Date.now());
@@ -39,10 +38,9 @@ export function useTimeout(
 
   useEffect(() => {
     if (playing) {
-      timeoutRef.current = setTimeout(handleCallback, duration);
+      timeoutRef.current = window.setTimeout(handleCallback, duration);
     }
 
-    // TODO: Really stupid casting required by TypeScript
-    return () => clearTimeout(timeoutRef.current as unknown as number);
+    return () => window.clearTimeout(timeoutRef.current);
   }, [duration, playing]);
 }

--- a/src/utilities/index.ts
+++ b/src/utilities/index.ts
@@ -1,3 +1,4 @@
 export {canUseDom} from './dom';
 export {noop} from './noop';
 export {filterNullishValuesFromObject} from './objects';
+export {mount} from './testing';

--- a/src/utilities/testing.ts
+++ b/src/utilities/testing.ts
@@ -1,0 +1,18 @@
+import {act, create} from 'react-test-renderer';
+import type {ReactTestRenderer} from 'react-test-renderer';
+
+type CreateArgs = Parameters<typeof create>;
+type Component = CreateArgs[0];
+type Options = CreateArgs[1];
+
+export function mount(component: Component, options?: Options) {
+  let wrapper: ReactTestRenderer | undefined;
+
+  act(() => {
+    wrapper = create(component, options);
+  });
+
+  // TODO: Figure out how to avoid this typecast.
+  // We may need to make this function async/await.
+  return wrapper as ReactTestRenderer;
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -14,10 +14,7 @@ const DTS_ENTRY_CONTENT = `export * from './types/index';`;
 
 const testConfig: vitestTypes.InlineConfig = {
   global: true,
-  // TODO: Using this (or JSDOM) breaks a bunch of tests with timers.
-  // Need to figure out what is causing this.
-  // https://github.com/beefchimi/react-hooks/issues/11
-  // environment: 'happy-dom',
+  environment: 'happy-dom',
 };
 
 // TODO: Do we actually need to include React DOM?


### PR DESCRIPTION
In order to default to `happy-dom`, we needed to update some tests. I'm not 100% sure why some of the `useInterval` changes were required, but I'm happy to find that tests are now working in both `node` and `DOM` environments.