### PR TITLE
🪝 [useInstantRef] New hook

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 export type {SetIntervalId, SetTimeoutId} from './types';
 
 export * from './useEventListener';
+export * from './useInstantRef';
 export * from './useInterval';
 export * from './useIsoLayoutEffect';
 export * from './useKeyPress';

--- a/src/useEventListener/tests/EventListenerComponent.tsx
+++ b/src/useEventListener/tests/EventListenerComponent.tsx
@@ -1,5 +1,6 @@
-import React, {useRef} from 'react';
+import React from 'react';
 
+import {useInstantRef} from '../../useInstantRef';
 import {useEventListener} from '../useEventListener';
 import type {EventListenerHookOptions} from '../types';
 
@@ -23,10 +24,10 @@ export function EventListenerComponent({
   disabled,
   preferLayoutEffect,
 }: EventListenerComponentProps) {
-  const buttonRef = useRef<HTMLButtonElement>(null);
+  const [buttonElement, buttonRef] = useInstantRef<HTMLButtonElement>();
 
   useEventListener({
-    target: buttonRef.current,
+    target: buttonElement,
     eventType,
     callback,
     options,

--- a/src/useEventListener/tests/useEventListener.test.tsx
+++ b/src/useEventListener/tests/useEventListener.test.tsx
@@ -46,14 +46,7 @@ describe('useEventListener', () => {
 
     it('registers on the provided component', () => {
       const mockCallback = vi.fn();
-
-      const {rerender} = mount(
-        <EventListenerComponent callback={mockCallback} />,
-      );
-
-      // TODO: Requires an immediate `rerender()` for the updated ref.
-      // https://github.com/beefchimi/react-hooks/issues/20
-      rerender(<EventListenerComponent callback={mockCallback} />);
+      mount(<EventListenerComponent callback={mockCallback} />);
 
       const button = screen.getByRole('button');
       userEvent.click(button);

--- a/src/useEventListener/useEventListener.ts
+++ b/src/useEventListener/useEventListener.ts
@@ -1,6 +1,7 @@
 import {useEffect, useRef} from 'react';
 
 import {useIsoLayoutEffect} from '../useIsoLayoutEffect';
+import type {GlobalEventCallback} from '../types';
 import type {EventListenerHookOptions} from './types';
 
 export function useEventListener({
@@ -27,9 +28,9 @@ export function useEventListener({
   // We might need to move `handleCallback()` out of the effect
   // and wrap with `useCallback()` if we find this to be a problem.
   usePreferredEffect(() => {
-    function handleCallback(event: any) {
+    const handleCallback: GlobalEventCallback = (event) => {
       callbackRef.current(event);
-    }
+    };
 
     if (!disabled && target) {
       target.addEventListener(eventType, handleCallback, options);

--- a/src/useInstantRef/index.ts
+++ b/src/useInstantRef/index.ts
@@ -1,0 +1,1 @@
+export {useInstantRef} from './useInstantRef';

--- a/src/useInstantRef/tests/InstantRefComponent.tsx
+++ b/src/useInstantRef/tests/InstantRefComponent.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+
+import {noop} from '../../utilities';
+import {useInstantRef} from '../useInstantRef';
+import {useFocusEffect} from './useFocusEffect';
+
+export interface InstantRefComponentProps {
+  onFocus(): void;
+}
+
+export function InstantRefComponent({onFocus}: InstantRefComponentProps) {
+  const [buttonElement, buttonRef] = useInstantRef<HTMLButtonElement>();
+
+  useFocusEffect(buttonElement);
+
+  return (
+    <div className="InstantRefComponent">
+      <button ref={buttonRef} type="button" onClick={noop} onFocus={onFocus}>
+        Instant Ref Component
+      </button>
+    </div>
+  );
+}

--- a/src/useInstantRef/tests/NormalRefComponent.tsx
+++ b/src/useInstantRef/tests/NormalRefComponent.tsx
@@ -1,0 +1,22 @@
+import React, {useRef} from 'react';
+
+import {noop} from '../../utilities';
+import {useFocusEffect} from './useFocusEffect';
+
+export interface NormalRefComponentProps {
+  onFocus(): void;
+}
+
+export function NormalRefComponent({onFocus}: NormalRefComponentProps) {
+  const buttonRef = useRef<HTMLButtonElement>(null);
+
+  useFocusEffect(buttonRef.current);
+
+  return (
+    <div className="NormalRefComponent">
+      <button ref={buttonRef} type="button" onClick={noop} onFocus={onFocus}>
+        Normal Ref Component
+      </button>
+    </div>
+  );
+}

--- a/src/useInstantRef/tests/useFocusEffect.ts
+++ b/src/useInstantRef/tests/useFocusEffect.ts
@@ -1,0 +1,16 @@
+import {useEffect} from 'react';
+
+// This is a contrived example, but effectively demonstrates the problem.
+// The code within the `useEffect` that relies on a `ref.current > DOM node`
+// will not be executed on initial render until React has re-rendered
+// to store reference to that DOM node.
+
+// If this `useEffect()` were pulled out of this custom hook
+// and used directly in the component, React actually would
+// work as expected. I am unsure of the exact mechanic that
+// leads to this problem.
+export function useFocusEffect(element: HTMLElement | null) {
+  useEffect(() => {
+    element?.focus();
+  }, [element]);
+}

--- a/src/useInstantRef/tests/useInstantRef.test.tsx
+++ b/src/useInstantRef/tests/useInstantRef.test.tsx
@@ -1,0 +1,42 @@
+import React from 'react';
+import {screen} from '@testing-library/react';
+
+import {mount} from '../../test/utilities';
+import {InstantRefComponent} from './InstantRefComponent';
+import {NormalRefComponent} from './NormalRefComponent';
+
+describe('useInstantRef', () => {
+  it('immediately triggers a re-render and defines a value', () => {
+    const mockOnFocus = vi.fn();
+    mount(<InstantRefComponent onFocus={mockOnFocus} />);
+
+    const buttonElement = screen.getByRole('button');
+
+    expect(mockOnFocus).toHaveBeenCalledTimes(1);
+    expect(document.activeElement).toBe(buttonElement);
+  });
+
+  describe('useRef', () => {
+    it('does not hold a reference to a DOM node on first render', () => {
+      const mockOnFocus = vi.fn();
+      mount(<NormalRefComponent onFocus={mockOnFocus} />);
+
+      const buttonElement = screen.getByRole('button');
+
+      expect(mockOnFocus).not.toHaveBeenCalled();
+      expect(document.activeElement).not.toBe(buttonElement);
+    });
+
+    it('will reference a DOM node once rerendered', () => {
+      const mockOnFocus = vi.fn();
+      const {rerender} = mount(<NormalRefComponent onFocus={mockOnFocus} />);
+
+      rerender(<NormalRefComponent onFocus={mockOnFocus} />);
+
+      const buttonElement = screen.getByRole('button');
+
+      expect(mockOnFocus).toHaveBeenCalledTimes(1);
+      expect(document.activeElement).toBe(buttonElement);
+    });
+  });
+});

--- a/src/useInstantRef/useInstantRef.ts
+++ b/src/useInstantRef/useInstantRef.ts
@@ -1,0 +1,33 @@
+import {useCallback, useState} from 'react';
+
+type InstantRefValue<T> = T | null;
+
+type InstantRefHookReturn<T> = [
+  InstantRefValue<T>,
+  (value: InstantRefValue<T>) => void,
+];
+
+// This hook promotes a React anti-pattern, but I've yet to
+// find a more eloquent solution for when you need to share
+// the ref between multiple hooks/effects (as opposed to
+// being isolated to a single `callback -> update` pattern).
+// If you are using multiple refs within a single component,
+// prefer using this hook only once (for whatever ref has
+// the highest priority). Since this hook forces a re-render,
+// all other calls to `useRef()` will receive their definition
+// as a result of this hooks re-render.
+
+// A demonstration of this hook's purpose can be found here:
+// https://codesandbox.io/s/element-ref-hooks-p8cgy?file=/src/App.tsx
+// https://codesandbox.io/s/testing-ref-and-hooks-0xeyr?file=/src/App.tsx
+
+export function useInstantRef<T>(): InstantRefHookReturn<T> {
+  const [currentValue, setCurrentValue] = useState<InstantRefValue<T>>(null);
+
+  const setRef = useCallback(
+    (value: InstantRefValue<T>) => setCurrentValue(value),
+    [],
+  );
+
+  return [currentValue, setRef];
+}

--- a/src/useKeyPress/tests/KeyPressComponent.tsx
+++ b/src/useKeyPress/tests/KeyPressComponent.tsx
@@ -2,6 +2,7 @@ import React, {useRef, useState} from 'react';
 import type {ChangeEventHandler} from 'react';
 
 import {noop} from '../../utilities';
+import {useInstantRef} from '../../useInstantRef';
 import {useKeyPress} from '../useKeyPress';
 import {KeyPressEventType} from '../types';
 import type {KeyPressCallback, KeyPressInput} from '../types';
@@ -15,7 +16,7 @@ const LABEL_ID = 'ExampleLabel';
 const INPUT_ID = 'ExampleInput';
 
 export function KeyPressComponent({input, callback}: KeyPressComponentProps) {
-  const inputRef = useRef<HTMLInputElement>(null);
+  const [inputElement, inputRef] = useInstantRef<HTMLInputElement>();
   const buttonRef = useRef<HTMLButtonElement>(null);
 
   const [value, setValue] = useState('');
@@ -26,7 +27,7 @@ export function KeyPressComponent({input, callback}: KeyPressComponentProps) {
 
   useKeyPress(input, callback, {
     eventType: KeyPressEventType.Up,
-    target: inputRef.current,
+    target: inputElement,
   });
 
   // TODO: The eslint-ing for this `label + input` combo seems overboard.

--- a/src/useKeyPress/tests/useKeyPress.test.tsx
+++ b/src/useKeyPress/tests/useKeyPress.test.tsx
@@ -144,15 +144,7 @@ describe('useKeyPress', () => {
         const mockKeys = ['a', 'b', 'c'];
         const mockCallback = vi.fn();
 
-        const {rerender} = mount(
-          <KeyPressComponent input={mockKeys} callback={mockCallback} />,
-        );
-
-        // TODO: Requires an immediate `rerender()` for the updated ref.
-        // https://github.com/beefchimi/react-hooks/issues/20
-        rerender(
-          <KeyPressComponent input={mockKeys} callback={mockCallback} />,
-        );
+        mount(<KeyPressComponent input={mockKeys} callback={mockCallback} />);
 
         const buttonElement = screen.getByRole('button');
         userEvent.type(buttonElement, 'abc');

--- a/src/useOutsideClick/tests/OutsideClickComponent.tsx
+++ b/src/useOutsideClick/tests/OutsideClickComponent.tsx
@@ -1,5 +1,6 @@
 import React, {useRef} from 'react';
 
+import {useInstantRef} from '../../useInstantRef';
 import {useOutsideClick} from '../useOutsideClick';
 import type {OutsideClickCallback} from '../types';
 
@@ -14,11 +15,11 @@ export function OutsideClickComponent({
   onOutsideClick,
   exclude = false,
 }: OutsideClickComponentProps) {
-  const buttonRef = useRef<HTMLButtonElement>(null);
+  const [buttonElement, buttonRef] = useInstantRef<HTMLButtonElement>();
   const outsideElementRef = useRef<HTMLParagraphElement>(null);
 
   useOutsideClick(
-    buttonRef.current,
+    buttonElement,
     onOutsideClick,
     exclude ? outsideElementRef.current : undefined,
   );

--- a/src/useOutsideClick/tests/useOutsideClick.test.tsx
+++ b/src/useOutsideClick/tests/useOutsideClick.test.tsx
@@ -26,16 +26,7 @@ describe('useOutsideClick', () => {
       const mockOnAction = vi.fn();
       const mockOnOutsideClick = vi.fn();
 
-      const {rerender} = mount(
-        <OutsideClickComponent
-          onAction={mockOnAction}
-          onOutsideClick={mockOnOutsideClick}
-        />,
-      );
-
-      // TODO: Requires an immediate `rerender()` for the updated ref.
-      // https://github.com/beefchimi/react-hooks/issues/20
-      rerender(
+      mount(
         <OutsideClickComponent
           onAction={mockOnAction}
           onOutsideClick={mockOnOutsideClick}
@@ -64,16 +55,7 @@ describe('useOutsideClick', () => {
     it('executes with mouse event', () => {
       const mockOnOutsideClick = vi.fn();
 
-      const {rerender} = mount(
-        <OutsideClickComponent
-          onAction={mockOnAction}
-          onOutsideClick={mockOnOutsideClick}
-        />,
-      );
-
-      // TODO: Requires an immediate `rerender()` for the updated ref.
-      // https://github.com/beefchimi/react-hooks/issues/20
-      rerender(
+      mount(
         <OutsideClickComponent
           onAction={mockOnAction}
           onOutsideClick={mockOnOutsideClick}
@@ -96,17 +78,7 @@ describe('useOutsideClick', () => {
     it('will not trigger outside click', () => {
       const mockOnOutsideClick = vi.fn();
 
-      const {rerender} = mount(
-        <OutsideClickComponent
-          exclude
-          onAction={mockOnAction}
-          onOutsideClick={mockOnOutsideClick}
-        />,
-      );
-
-      // TODO: Requires an immediate `rerender()` for the updated ref.
-      // https://github.com/beefchimi/react-hooks/issues/20
-      rerender(
+      mount(
         <OutsideClickComponent
           exclude
           onAction={mockOnAction}


### PR DESCRIPTION
While not the most eloquent solution, this new hook aims to resolve the issues surfaced here: https://github.com/beefchimi/react-hooks/issues/20

This hook allows us to trigger an immediate re-render so that our `ref` holds a non-nullish definition.

I do have concerns about this hook... I am worried that it could produce stale ref values under certain circumstances. This will require time in the wild in order to see how well the solution works.

I have created some Sandbox examples for reference:
- https://codesandbox.io/s/element-ref-hooks-p8cgy?file=/src/App.tsx
- https://codesandbox.io/s/testing-ref-and-hooks-0xeyr?file=/src/App.tsx