### PR TITLE
🪝 [useCountdown] New hook

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 export type {SetIntervalId, SetTimeoutId} from './types';
 
+export * from './useCountdown';
 export * from './useEventListener';
 export * from './useInstantRef';
 export * from './useInterval';

--- a/src/types.ts
+++ b/src/types.ts
@@ -5,5 +5,7 @@ export interface BasicObject {
 export type GlobalEventCallback = (event: any) => void;
 export type GlobalEventTarget = Document | Window | HTMLElement | null;
 
+export type UtcMilliseconds = number;
+
 export type SetIntervalId = number | ReturnType<typeof setInterval>;
 export type SetTimeoutId = number | ReturnType<typeof setTimeout>;

--- a/src/useCountdown/index.ts
+++ b/src/useCountdown/index.ts
@@ -1,0 +1,2 @@
+export {useCountdown} from './useCountdown';
+export type {CountdownCallback} from './types';

--- a/src/useCountdown/tests/useCountdown.test.tsx
+++ b/src/useCountdown/tests/useCountdown.test.tsx
@@ -1,0 +1,257 @@
+import {renderHook} from '@testing-library/react-hooks';
+
+import {timeMeasurement} from '../../utilities';
+import type {UtcMilliseconds} from '../../types';
+
+import {useCountdown} from '../useCountdown';
+
+const MOCK_DATE_ARGS = [1988, 10, 1];
+const MOCK_DATE_24H_LATER = MOCK_DATE_ARGS[2] + 1;
+
+const oneSecond = timeMeasurement.msPerSec;
+const halfSecond = oneSecond / 2;
+const twoSeconds = oneSecond * 2;
+const threeSeconds = oneSecond * 3;
+const fourSeconds = oneSecond * 4;
+
+describe('useCountdown', () => {
+  let mockTimeStart = 0;
+  let mockTime24hLater = 0;
+
+  beforeEach(() => {
+    const mockDateStart = new Date(
+      MOCK_DATE_ARGS[0],
+      MOCK_DATE_ARGS[1],
+      MOCK_DATE_ARGS[2],
+    );
+    const mockDate24hLater = new Date(
+      MOCK_DATE_ARGS[0],
+      MOCK_DATE_ARGS[1],
+      MOCK_DATE_24H_LATER,
+    );
+
+    mockTimeStart = mockDateStart.getTime();
+    mockTime24hLater = mockDate24hLater.getTime();
+
+    vi.useFakeTimers();
+    vi.setSystemTime(mockDateStart);
+  });
+
+  afterEach(() => {
+    vi.clearAllTimers();
+    vi.useRealTimers();
+  });
+
+  describe('callback', () => {
+    it('executes immediately', () => {
+      const mockCallback = vi.fn((difference) => difference);
+
+      renderHook(() => useCountdown(mockCallback, mockTimeStart));
+
+      expect(mockCallback).toHaveBeenCalledTimes(1);
+    });
+
+    it('executes again after first second', () => {
+      const mockCallback = vi.fn((difference) => difference);
+
+      renderHook(() => useCountdown(mockCallback, mockTimeStart));
+
+      vi.advanceTimersByTime(oneSecond);
+      expect(mockCallback).toHaveBeenCalledTimes(2);
+      expect(mockCallback).not.toHaveBeenCalledTimes(3);
+    });
+
+    it('executes multiple times after enough time has passed', () => {
+      const mockCallback = vi.fn((difference) => difference);
+      const iterations = 5;
+
+      renderHook(() => useCountdown(mockCallback, mockTimeStart));
+
+      vi.advanceTimersByTime(oneSecond * iterations);
+      // Has been called `iterations + 1` because the `callback`
+      // fires immediately upon render, and then the timers
+      // run at 1 second intervals.
+      expect(mockCallback).toHaveBeenCalledTimes(iterations + 1);
+    });
+  });
+
+  describe('timeTarget', () => {
+    it('returns 0 as first result when using `Date.now()`', () => {
+      const mockCallback = vi.fn((difference) => difference);
+
+      renderHook(() => useCountdown(mockCallback, mockTimeStart));
+
+      expect(mockCallback).toHaveBeenCalledWith(0);
+    });
+
+    it('will produce negative 1 second increments when using `Date.now()`', () => {
+      const mockCallback = vi.fn((difference) => difference);
+
+      renderHook(() => useCountdown(mockCallback, mockTimeStart));
+
+      vi.advanceTimersByTime(oneSecond);
+      expect(mockCallback).toHaveBeenCalledWith(-Math.abs(oneSecond));
+
+      vi.advanceTimersByTime(oneSecond);
+      expect(mockCallback).toHaveBeenCalledWith(-Math.abs(twoSeconds));
+
+      vi.advanceTimersByTime(oneSecond);
+      expect(mockCallback).toHaveBeenCalledWith(-Math.abs(threeSeconds));
+
+      vi.advanceTimersByTime(oneSecond - 1);
+      expect(mockCallback).not.toHaveBeenCalledWith(-Math.abs(fourSeconds));
+
+      vi.advanceTimersByTime(1);
+      expect(mockCallback).toHaveBeenCalledWith(-Math.abs(fourSeconds));
+    });
+
+    it('will produce a result reduced by 1 second per interval', () => {
+      const mockCallback = vi.fn((difference) => difference);
+      const initialOffset = mockTime24hLater - mockTimeStart;
+
+      renderHook(() => useCountdown(mockCallback, mockTime24hLater));
+
+      expect(mockCallback).toHaveBeenCalledWith(initialOffset);
+      expect(initialOffset).toStrictEqual(timeMeasurement.msPerDay);
+
+      vi.advanceTimersByTime(oneSecond);
+      expect(mockCallback).toHaveBeenCalledWith(initialOffset - oneSecond);
+
+      vi.advanceTimersByTime(oneSecond);
+      expect(mockCallback).toHaveBeenCalledWith(initialOffset - twoSeconds);
+
+      vi.advanceTimersByTime(oneSecond);
+      expect(mockCallback).toHaveBeenCalledWith(initialOffset - threeSeconds);
+
+      vi.advanceTimersByTime(oneSecond - 1);
+      expect(mockCallback).not.toHaveBeenCalledWith(
+        initialOffset - fourSeconds,
+      );
+
+      vi.advanceTimersByTime(1);
+      expect(mockCallback).toHaveBeenCalledWith(initialOffset - fourSeconds);
+    });
+
+    it('immediately returns new `difference` when updated mid-iteration', () => {
+      const mockCallback = vi.fn((difference) => difference);
+      const initialOffset = mockTime24hLater - mockTimeStart;
+
+      const {rerender} = renderHook(
+        ({timeTarget}: {timeTarget: UtcMilliseconds}) =>
+          useCountdown(mockCallback, timeTarget),
+        {initialProps: {timeTarget: mockTime24hLater}},
+      );
+
+      expect(mockCallback).toHaveBeenCalledWith(initialOffset);
+
+      vi.advanceTimersByTime(oneSecond);
+      expect(mockCallback).toHaveBeenCalledWith(initialOffset - oneSecond);
+
+      rerender({timeTarget: Date.now()});
+
+      expect(mockCallback).toHaveBeenCalledWith(0);
+
+      vi.advanceTimersByTime(oneSecond);
+      expect(mockCallback).toHaveBeenCalledWith(-Math.abs(oneSecond));
+
+      expect(mockCallback).toHaveBeenCalledTimes(4);
+      expect(mockCallback).not.toHaveBeenCalledTimes(5);
+    });
+
+    it('continues mid-interval when `timeRange` changes while iterating', () => {
+      const mockCallback = vi.fn((difference) => difference);
+      const initialOffset = mockTime24hLater - mockTimeStart;
+
+      const {rerender} = renderHook(
+        ({timeTarget}: {timeTarget: UtcMilliseconds}) =>
+          useCountdown(mockCallback, timeTarget),
+        {initialProps: {timeTarget: mockTime24hLater}},
+      );
+
+      expect(mockCallback).toHaveBeenCalledWith(initialOffset);
+
+      vi.advanceTimersByTime(oneSecond);
+      expect(mockCallback).toHaveBeenCalledWith(initialOffset - oneSecond);
+
+      vi.advanceTimersByTime(halfSecond);
+      rerender({timeTarget: Date.now()});
+
+      expect(mockCallback).toHaveBeenCalledWith(0);
+
+      vi.advanceTimersByTime(halfSecond);
+      expect(mockCallback).toHaveBeenCalledWith(-Math.abs(halfSecond));
+
+      vi.advanceTimersByTime(oneSecond);
+      expect(mockCallback).toHaveBeenCalledWith(
+        -Math.abs(oneSecond + halfSecond),
+      );
+
+      expect(mockCallback).toHaveBeenCalledTimes(5);
+      expect(mockCallback).not.toHaveBeenCalledTimes(6);
+    });
+  });
+
+  describe('pause', () => {
+    it('does not execute when `true`', () => {
+      const mockCallback = vi.fn((timestamp) => timestamp);
+
+      renderHook(() => useCountdown(mockCallback, mockTimeStart, true));
+
+      vi.advanceTimersByTime(twoSeconds);
+      expect(mockCallback).not.toHaveBeenCalled();
+    });
+
+    it('stops performing iterations', () => {
+      const mockCallback = vi.fn((difference) => difference);
+
+      const {rerender} = renderHook(
+        ({pause}: {pause: boolean}) =>
+          useCountdown(mockCallback, mockTimeStart, pause),
+        {initialProps: {pause: false}},
+      );
+
+      vi.advanceTimersByTime(oneSecond);
+      expect(mockCallback).toHaveBeenCalledTimes(2);
+
+      rerender({pause: true});
+
+      vi.advanceTimersByTime(fourSeconds);
+      expect(mockCallback).not.toHaveBeenCalledTimes(3);
+    });
+
+    it('will restart from the paused position when toggled back and forth', () => {
+      const mockCallback = vi.fn((difference) => difference);
+
+      const {rerender} = renderHook(
+        ({pause}: {pause: boolean}) =>
+          useCountdown(mockCallback, mockTimeStart, pause),
+        {initialProps: {pause: false}},
+      );
+
+      vi.advanceTimersByTime(halfSecond);
+      expect(mockCallback).toHaveBeenCalledTimes(1);
+
+      rerender({pause: true});
+
+      vi.advanceTimersByTime(fourSeconds);
+      expect(mockCallback).not.toHaveBeenCalledTimes(2);
+
+      rerender({pause: false});
+
+      vi.advanceTimersByTime(halfSecond);
+      expect(mockCallback).toHaveBeenCalledTimes(2);
+
+      vi.advanceTimersByTime(oneSecond - 1);
+
+      rerender({pause: true});
+
+      vi.advanceTimersByTime(fourSeconds);
+      expect(mockCallback).not.toHaveBeenCalledTimes(3);
+
+      rerender({pause: false});
+
+      vi.advanceTimersByTime(1);
+      expect(mockCallback).toHaveBeenCalledTimes(3);
+    });
+  });
+});

--- a/src/useCountdown/types.ts
+++ b/src/useCountdown/types.ts
@@ -1,0 +1,3 @@
+import type {UtcMilliseconds} from '../types';
+
+export type CountdownCallback = (difference: UtcMilliseconds) => void;

--- a/src/useCountdown/useCountdown.ts
+++ b/src/useCountdown/useCountdown.ts
@@ -1,0 +1,44 @@
+import {useEffect, useRef} from 'react';
+
+import {timeMeasurement} from '../utilities';
+import {useInterval} from '../useInterval';
+import type {UtcMilliseconds} from '../types';
+
+import type {CountdownCallback} from './types';
+
+// TODO: Consider allowing an `option` to specify `interval` duration.
+export function useCountdown(
+  callback: CountdownCallback,
+  timeTarget: UtcMilliseconds,
+  pause = false,
+): void {
+  const callbackRef = useRef<CountdownCallback>();
+
+  function handleCallback(timestamp: UtcMilliseconds) {
+    callbackRef.current?.(timeTarget - timestamp);
+  }
+
+  useEffect(() => {
+    callbackRef.current = callback;
+  }, [callback]);
+
+  // Trigger `callback` on first render and subsequent changes
+  // of `timeTarget` arg. This saves us from passing
+  // `skipFirstInterval: true` to `useInterval()` and gets
+  // around the problem of not being able to declare `timeTarget`
+  // as a depencency of that hook. We do need to manually skip
+  // first render if `pause` is `true`, and therefor keep it
+  // out of our dependencies array.
+  useEffect(() => {
+    if (!pause) {
+      handleCallback(Date.now());
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [timeTarget]);
+
+  useInterval(handleCallback, {
+    duration: timeMeasurement.msPerSec,
+    allowPausing: true,
+    playing: !pause,
+  });
+}

--- a/src/useInterval/tests/useInterval.test.tsx
+++ b/src/useInterval/tests/useInterval.test.tsx
@@ -9,7 +9,7 @@ describe('useInterval', () => {
 
   beforeEach(() => {
     const mockDate = new Date(1988, 10, 1);
-    mockTimestamp = mockDate.valueOf();
+    mockTimestamp = mockDate.getTime();
 
     vi.useFakeTimers();
     vi.setSystemTime(mockDate);
@@ -56,11 +56,12 @@ describe('useInterval', () => {
 
     it('executes multiple times after enough time has passed', () => {
       const mockCallback = vi.fn((timestamp) => timestamp);
+      const iterations = 3;
 
       renderHook(() => useInterval(mockCallback, {duration: mockDuration}));
 
-      vi.advanceTimersByTime(mockDuration * 3);
-      expect(mockCallback).toHaveBeenCalledTimes(3);
+      vi.advanceTimersByTime(mockDuration * iterations);
+      expect(mockCallback).toHaveBeenCalledTimes(iterations);
       expect(mockCallback).toHaveBeenCalledWith(mockTimestamp);
     });
   });

--- a/src/useInterval/types.ts
+++ b/src/useInterval/types.ts
@@ -1,6 +1,8 @@
+import type {UtcMilliseconds} from '../types';
+
 // TODO: Consider supporting setInterval paramaters.
 // TODO: Maybe `any` instead of `void` (or use generic)?
-export type IntervalCallback = (timestamp: number) => void;
+export type IntervalCallback = (timestamp: UtcMilliseconds) => void;
 
 export interface IntervalHookOptions {
   duration?: number;

--- a/src/useInterval/useInterval.ts
+++ b/src/useInterval/useInterval.ts
@@ -1,5 +1,6 @@
 import {useCallback, useEffect, useRef} from 'react';
 
+import {filterNullishValuesFromObject} from '../utilities';
 import type {SetIntervalId, SetTimeoutId} from '../types';
 import type {
   IntervalCallback,
@@ -19,9 +20,11 @@ export function useInterval(
   callback: IntervalCallback,
   options?: IntervalHookOptions,
 ): void {
+  // NOTE: This wouldn't be necessary if we always require
+  // `duration` to be passed (making the `options` object required).
   const {duration, playing, allowPausing, skipFirstInterval} = {
     ...DEFAULT_OPTIONS,
-    ...options,
+    ...filterNullishValuesFromObject<IntervalHookOptions>(options ?? {}),
   };
 
   const initialTimeData: IntervalTimeData = {

--- a/src/useTimeout/tests/useTimeout.test.tsx
+++ b/src/useTimeout/tests/useTimeout.test.tsx
@@ -9,7 +9,7 @@ describe('useTimeout', () => {
 
   beforeEach(() => {
     const mockDate = new Date(1988, 10, 1);
-    mockTimestamp = mockDate.valueOf();
+    mockTimestamp = mockDate.getTime();
 
     vi.useFakeTimers();
     vi.setSystemTime(mockDate);

--- a/src/useTimeout/types.ts
+++ b/src/useTimeout/types.ts
@@ -1,6 +1,8 @@
+import type {UtcMilliseconds} from '../types';
+
 // TODO: Consider supporting setTimeout paramaters.
 // TODO: Maybe `any` instead of `void` (or use generic)?
-export type TimeoutCallback = (timestamp: number) => void;
+export type TimeoutCallback = (timestamp: UtcMilliseconds) => void;
 
 export interface TimeoutHookOptions {
   duration?: number;

--- a/src/utilities/index.ts
+++ b/src/utilities/index.ts
@@ -2,3 +2,4 @@ export {canUseDom} from './dom';
 export {noop} from './noop';
 export {leftPadNumber} from './numbers';
 export {filterNullishValuesFromObject} from './objects';
+export {timeMeasurement, msToTime} from './time';

--- a/src/utilities/index.ts
+++ b/src/utilities/index.ts
@@ -1,3 +1,4 @@
 export {canUseDom} from './dom';
 export {noop} from './noop';
+export {leftPadNumber} from './numbers';
 export {filterNullishValuesFromObject} from './objects';

--- a/src/utilities/numbers.ts
+++ b/src/utilities/numbers.ts
@@ -1,0 +1,12 @@
+export interface LeftPadNumberOptions {
+  padding?: number;
+  prefix?: string;
+}
+
+export function leftPadNumber(
+  value: number,
+  options: LeftPadNumberOptions = {},
+) {
+  const {padding = 2, prefix = '0'} = options;
+  return value.toString().padStart(padding, prefix);
+}

--- a/src/utilities/tests/numbers.test.ts
+++ b/src/utilities/tests/numbers.test.ts
@@ -1,0 +1,41 @@
+import {leftPadNumber} from '../numbers';
+
+describe('Number utilities', () => {
+  describe('leftPadNumber', () => {
+    describe('default options', () => {
+      it('returns a string with a single leading `0` when passed a single-digit value', () => {
+        const result = leftPadNumber(9);
+        expect(result).toBe('09');
+      });
+
+      it('returns a string without a leading `0` when passed a double-digit value', () => {
+        const result = leftPadNumber(24);
+        expect(result).toBe('24');
+      });
+    });
+
+    describe('padding', () => {
+      it('returns without any prefix values when `padding` is less than value length', () => {
+        const result = leftPadNumber(1234, {padding: 3});
+        expect(result).toBe('1234');
+      });
+
+      it('returns without any prefix values when `padding` is equal to value length', () => {
+        const result = leftPadNumber(12345, {padding: 5});
+        expect(result).toBe('12345');
+      });
+
+      it('returns with leading prefix values when `padding` is greater than value length', () => {
+        const result = leftPadNumber(56, {padding: 6});
+        expect(result).toBe('000056');
+      });
+    });
+
+    describe('prefix', () => {
+      it('returns with custom prefix value', () => {
+        const result = leftPadNumber(8, {prefix: '-'});
+        expect(result).toBe('-8');
+      });
+    });
+  });
+});

--- a/src/utilities/tests/objects.test.ts
+++ b/src/utilities/tests/objects.test.ts
@@ -1,0 +1,50 @@
+import {filterNullishValuesFromObject} from '../objects';
+
+describe('Object utilities', () => {
+  describe('filterNullishValuesFromObject', () => {
+    const truthyValues = {
+      one: 1,
+      two: '2',
+      three: [1, 2, 3],
+      four: {
+        infinity: 'and beyond',
+      },
+      five: true,
+      six: new Map(),
+    };
+
+    const nullishValues = {
+      foo: null,
+      bar: undefined,
+    };
+
+    const questionableValues = {
+      definite: false,
+      falsey: 0,
+      maybe: NaN,
+      null: 'null?',
+      undefined: 'key does not equal value',
+    };
+
+    const mockObject = {
+      ...truthyValues,
+      ...nullishValues,
+      ...questionableValues,
+    };
+
+    it('returns object with all keys pointing to nullish values removed', () => {
+      const result = filterNullishValuesFromObject(mockObject);
+
+      expect(result).toStrictEqual({
+        ...truthyValues,
+        ...questionableValues,
+      });
+
+      expect(result).not.toHaveProperty('for');
+      expect(result).not.toHaveProperty('bar');
+
+      expect(result).toHaveProperty('maybe');
+      expect(result).toHaveProperty('null');
+    });
+  });
+});

--- a/src/utilities/tests/time.test.ts
+++ b/src/utilities/tests/time.test.ts
@@ -1,0 +1,43 @@
+import {timeMeasurement, msToTime} from '../time';
+
+const {msPerSec, msPerMin, msPerHr, msPerDay} = timeMeasurement;
+
+describe('Time utilities', () => {
+  const ms1Day = msPerDay;
+  const ms15Hrs = msPerHr * 15;
+  const ms10hrs15mins = msPerHr * 10 + msPerMin * 15;
+  const ms4hrs15mins5secs = msPerHr * 4 + msPerMin * 15 + msPerSec * 5;
+
+  describe('msToTime', () => {
+    it('returns 24-hour breakdown from provided UTC milliseconds', () => {
+      const greaterthan24Hrs = msToTime(
+        ms1Day + ms15Hrs + ms10hrs15mins + ms4hrs15mins5secs,
+      );
+
+      expect(greaterthan24Hrs).toStrictEqual({
+        days: 2,
+        hours: 5,
+        minutes: 30,
+        seconds: 5,
+      });
+
+      const lessThan24Hrs = msToTime(ms10hrs15mins + ms4hrs15mins5secs);
+
+      expect(lessThan24Hrs).toStrictEqual({
+        days: 0,
+        hours: 14,
+        minutes: 30,
+        seconds: 5,
+      });
+
+      const lessThan12Hrs = msToTime(ms15Hrs - ms4hrs15mins5secs);
+
+      expect(lessThan12Hrs).toStrictEqual({
+        days: 0,
+        hours: 10,
+        minutes: 44,
+        seconds: 55,
+      });
+    });
+  });
+});

--- a/src/utilities/time.ts
+++ b/src/utilities/time.ts
@@ -1,0 +1,41 @@
+import type {UtcMilliseconds} from '../types';
+
+const hrsPerDay = 24;
+
+const minsPerHr = 60;
+const minsPerDay = minsPerHr * hrsPerDay;
+
+const secsPerMin = 60;
+const secsPerHr = secsPerMin * minsPerHr;
+const secsPerDay = secsPerHr * hrsPerDay;
+
+const msPerSec = 1000;
+const msPerMin = msPerSec * secsPerMin;
+const msPerHr = msPerMin * minsPerHr;
+const msPerDay = msPerHr * hrsPerDay;
+
+export const timeMeasurement = {
+  hrsPerDay,
+  minsPerHr,
+  minsPerDay,
+  secsPerMin,
+  secsPerHr,
+  secsPerDay,
+  msPerSec,
+  msPerMin,
+  msPerHr,
+  msPerDay,
+};
+
+export function msToTime(ms: UtcMilliseconds) {
+  const seconds = Math.floor(ms / msPerSec);
+  const minutes = Math.floor(seconds / secsPerMin);
+  const hours = Math.floor(minutes / minsPerHr);
+
+  return {
+    days: Math.floor(hours / hrsPerDay),
+    hours: hours % hrsPerDay,
+    minutes: minutes % minsPerHr,
+    seconds: seconds % secsPerMin,
+  };
+}


### PR DESCRIPTION
This PR introduces a new `useCountdown()` hook for tracking the time between the provided date _(in `milliseconds`)_ and `Date.now()`.

### Example usage

```tsx
const DATE_TOMORROW = new Date(Date.now() + 1 * 24 * 60 * 60 * 1000);

function Example() {
  const [diff, setDiff] = useState();

  function handleCallback(difference) {
    setDiff(difference);
  }

  // Upon first render, the `diff` should be `86400000` (number of milliseconds in a day),
  // since we have passed a `timeTarget` of exactly 24-hours from the moment of instantiation.
  // Internally, `useCountdown()` compares against `Date.now()`.
  useCountdown(handleCallback, DATE_TOMORROW);

  // `diff` will update after every `1` second, returning a "time until" result
  // counting down until eventually returning a `negative` "time since" value.
  return <p>Difference: {diff}</p>
}
```

**Included in this PR:**
- Small _(non-breaking)_ improvements to `useInterval()`.
- New `UtcMilliseconds` type.
- Small test clarifications.
- Test coverage for `objects.ts` utility.
- New `leftPadNumber()` number utility.
- New `msToTime()` time utility.
- New `timeMeasurement` helper object.

#### Possible considerations for a `options` argument:

```tsx
enum CountdownInterval {
  Miliseconds = 'miliseconds',
  Seconds = 'seconds',
}

export interface CountdownHookOptions {
  interval?: CountdownInterval;
  playing?: boolean;
  allowPausing?: boolean;
  skipFirstInterval?: boolean;
}

const DEFAULT_OPTIONS: Required<CountdownHookOptions> = {
  interval: CountdownInterval.Seconds,
  playing: true,
  allowPausing: false,
  skipFirstInterval: false,
};
```

#### For future reference, here is a slight alternative to the `msToTime()` function:

```tsx
function msToTime(ms: UtcMilliseconds) {
  const days = Math.floor(ms / msPerDay);
  const hours = Math.floor(ms / msPerHr) - hrsPerDay * days;
  const minutes =
    Math.floor(ms / msPerMin) - minsPerDay * days - minsPerHr * hours;
  const seconds =
    Math.floor(ms / msPerSec) -
    secsPerDay * days -
    secsPerHr * hours -
    secsPerMin * minutes;

  return {
    days,
    hours,
    minutes,
    seconds,
  };
}
```