### PR TITLE
✨ [useInterval] Add new onPause option

### DIFF
--- a/src/useCountdown/useCountdown.ts
+++ b/src/useCountdown/useCountdown.ts
@@ -1,4 +1,4 @@
-import {useEffect, useRef} from 'react';
+import {useCallback, useEffect} from 'react';
 
 import {timeMeasurement} from '../utilities';
 import {useInterval} from '../useInterval';
@@ -12,15 +12,12 @@ export function useCountdown(
   timeTarget: UtcMilliseconds,
   pause = false,
 ): void {
-  const callbackRef = useRef<CountdownCallback>();
-
-  function handleCallback(timestamp: UtcMilliseconds) {
-    callbackRef.current?.(timeTarget - timestamp);
-  }
-
-  useEffect(() => {
-    callbackRef.current = callback;
-  }, [callback]);
+  const handleCallback: CountdownCallback = useCallback(
+    (timestamp: UtcMilliseconds) => {
+      callback(timeTarget - timestamp);
+    },
+    [callback, timeTarget],
+  );
 
   // Trigger `callback` on first render and subsequent changes
   // of `timeTarget` arg. This saves us from passing

--- a/src/useInterval/types.ts
+++ b/src/useInterval/types.ts
@@ -4,19 +4,22 @@ import type {UtcMilliseconds} from '../types';
 // TODO: Maybe `any` instead of `void` (or use generic)?
 export type IntervalCallback = (timestamp: UtcMilliseconds) => void;
 
+// TODO: Not currently returing this data,
+// but can revisit if/when we want to support it.
+export interface IntervalTimeData {
+  // TODO: Would be nice to type this between `0-100`
+  progress: number;
+  timeRemaining: number;
+}
+
+export type IntervalPauseCallback = (timeData: IntervalTimeData) => void;
+
 export interface IntervalHookOptions {
   duration?: number;
   playing?: boolean;
   allowPausing?: boolean;
   skipFirstInterval?: boolean;
-}
-
-// TODO: Not currently returing this data,
-// but can revisit if/when we want to support it.
-export interface IntervalTimeData {
-  // TODO: Would be nice to type this between `0-100`
-  // progress: number;
-  timeRemaining: number;
+  onPause?: IntervalPauseCallback;
 }
 
 export interface DelayFnArgs {

--- a/src/utilities/index.ts
+++ b/src/utilities/index.ts
@@ -1,5 +1,10 @@
 export {canUseDom} from './dom';
 export {noop} from './noop';
-export {leftPadNumber} from './numbers';
+
+export {flipNumberSign, leftPadNumber} from './numbers';
+export type {LeftPadNumberOptions} from './numbers';
+
 export {filterNullishValuesFromObject} from './objects';
-export {timeMeasurement, msToTime} from './time';
+
+export {timeMeasurement, flipTimeSign, msToTime} from './time';
+export type {Time24HourBreakdown} from './time';

--- a/src/utilities/numbers.ts
+++ b/src/utilities/numbers.ts
@@ -3,6 +3,10 @@ export interface LeftPadNumberOptions {
   prefix?: string;
 }
 
+export function flipNumberSign(value: number) {
+  return value ? -value : value;
+}
+
 export function leftPadNumber(
   value: number,
   options: LeftPadNumberOptions = {},

--- a/src/utilities/tests/numbers.test.ts
+++ b/src/utilities/tests/numbers.test.ts
@@ -1,6 +1,23 @@
-import {leftPadNumber} from '../numbers';
+import {flipNumberSign, leftPadNumber} from '../numbers';
 
 describe('Number utilities', () => {
+  describe('flipNumberSign', () => {
+    it('flips positive to negative value', () => {
+      const negativeResult = flipNumberSign(1);
+      expect(negativeResult).toBe(-1);
+    });
+
+    it('flips negative to positive value', () => {
+      const positiveResult = flipNumberSign(-1);
+      expect(positiveResult).toBe(1);
+    });
+
+    it('does not flip `0` value', () => {
+      const zeroResult = flipNumberSign(0);
+      expect(zeroResult).toBe(0);
+    });
+  });
+
   describe('leftPadNumber', () => {
     describe('default options', () => {
       it('returns a string with a single leading `0` when passed a single-digit value', () => {

--- a/src/utilities/tests/time.test.ts
+++ b/src/utilities/tests/time.test.ts
@@ -1,17 +1,73 @@
-import {timeMeasurement, msToTime} from '../time';
+import {timeMeasurement, flipTimeSign, msToTime} from '../time';
+import type {Time24HourBreakdown} from '../time';
 
 const {msPerSec, msPerMin, msPerHr, msPerDay} = timeMeasurement;
 
 describe('Time utilities', () => {
   const ms1Day = msPerDay;
   const ms15Hrs = msPerHr * 15;
-  const ms10hrs15mins = msPerHr * 10 + msPerMin * 15;
-  const ms4hrs15mins5secs = msPerHr * 4 + msPerMin * 15 + msPerSec * 5;
+  const ms10Hrs15Mins = msPerHr * 10 + msPerMin * 15;
+  const ms4Hrs15Mins5Secs = msPerHr * 4 + msPerMin * 15 + msPerSec * 5;
+
+  const ms11Days10Hrs20Mins54Secs = 987654321;
+
+  describe('flipTimeSign', () => {
+    it('flips positive values to negative', () => {
+      const mockPositiveTime: Time24HourBreakdown = {
+        days: 0,
+        hours: 1,
+        minutes: 10,
+        seconds: 20,
+      };
+      const result = flipTimeSign(mockPositiveTime);
+
+      expect(result).toStrictEqual({
+        days: 0,
+        hours: -1,
+        minutes: -10,
+        seconds: -20,
+      });
+    });
+
+    it('flips negative values to positive', () => {
+      const mockNegativeTime: Time24HourBreakdown = {
+        days: -4,
+        hours: -5,
+        minutes: -23,
+        seconds: -2,
+      };
+      const result = flipTimeSign(mockNegativeTime);
+
+      expect(result).toStrictEqual({
+        days: 4,
+        hours: 5,
+        minutes: 23,
+        seconds: 2,
+      });
+    });
+
+    it('does not flip sign on `0` values', () => {
+      const mockMixedTime: Time24HourBreakdown = {
+        days: 0,
+        hours: 1,
+        minutes: 0,
+        seconds: -1,
+      };
+      const result = flipTimeSign(mockMixedTime);
+
+      expect(result).toStrictEqual({
+        days: 0,
+        hours: -1,
+        minutes: 0,
+        seconds: 1,
+      });
+    });
+  });
 
   describe('msToTime', () => {
     it('returns 24-hour breakdown from provided UTC milliseconds', () => {
       const greaterthan24Hrs = msToTime(
-        ms1Day + ms15Hrs + ms10hrs15mins + ms4hrs15mins5secs,
+        ms1Day + ms15Hrs + ms10Hrs15Mins + ms4Hrs15Mins5Secs,
       );
 
       expect(greaterthan24Hrs).toStrictEqual({
@@ -21,7 +77,7 @@ describe('Time utilities', () => {
         seconds: 5,
       });
 
-      const lessThan24Hrs = msToTime(ms10hrs15mins + ms4hrs15mins5secs);
+      const lessThan24Hrs = msToTime(ms10Hrs15Mins + ms4Hrs15Mins5Secs);
 
       expect(lessThan24Hrs).toStrictEqual({
         days: 0,
@@ -30,13 +86,93 @@ describe('Time utilities', () => {
         seconds: 5,
       });
 
-      const lessThan12Hrs = msToTime(ms15Hrs - ms4hrs15mins5secs);
+      const lessThan12Hrs = msToTime(ms15Hrs - ms4Hrs15Mins5Secs);
 
       expect(lessThan12Hrs).toStrictEqual({
         days: 0,
         hours: 10,
         minutes: 44,
         seconds: 55,
+      });
+    });
+
+    it('returns breakdown from positive milliseconds', () => {
+      const ms18Secs = msToTime(msPerSec * 18);
+
+      expect(ms18Secs).toStrictEqual({
+        days: 0,
+        hours: 0,
+        minutes: 0,
+        seconds: 18,
+      });
+    });
+
+    it('rounds down all properties to the nearest value', () => {
+      const roundedDownWhole = msToTime(ms11Days10Hrs20Mins54Secs);
+
+      expect(roundedDownWhole).toStrictEqual({
+        days: 11,
+        hours: 10,
+        minutes: 20,
+        seconds: 54,
+      });
+
+      const roundedDownDecimals = msToTime(ms11Days10Hrs20Mins54Secs / 10000);
+
+      expect(roundedDownDecimals).toStrictEqual({
+        days: 0,
+        hours: 0,
+        minutes: 1,
+        seconds: 38,
+      });
+
+      const lessThan1Min = msToTime(msPerMin - 1);
+
+      expect(lessThan1Min).toStrictEqual({
+        days: 0,
+        hours: 0,
+        minutes: 0,
+        seconds: 59,
+      });
+
+      const lessThan1Sec = msToTime(msPerSec - 1);
+
+      expect(lessThan1Sec).toStrictEqual({
+        days: 0,
+        hours: 0,
+        minutes: 0,
+        seconds: 0,
+      });
+    });
+
+    it('returns breakdown from `0` milliseconds', () => {
+      const outOfTime = msToTime(0);
+
+      expect(outOfTime).toStrictEqual({
+        days: 0,
+        hours: 0,
+        minutes: 0,
+        seconds: 0,
+      });
+    });
+
+    it('returns breakdown from negative milliseconds', () => {
+      const timeAgo1Sec = msToTime(-msPerSec);
+
+      expect(timeAgo1Sec).toStrictEqual({
+        days: 0,
+        hours: 0,
+        minutes: 0,
+        seconds: -1,
+      });
+
+      const timeAgo11Days = msToTime(-ms11Days10Hrs20Mins54Secs);
+
+      expect(timeAgo11Days).toStrictEqual({
+        days: -11,
+        hours: -10,
+        minutes: -20,
+        seconds: -54,
       });
     });
   });

--- a/src/utilities/time.ts
+++ b/src/utilities/time.ts
@@ -1,4 +1,12 @@
 import type {UtcMilliseconds} from '../types';
+import {flipNumberSign} from './numbers';
+
+export interface Time24HourBreakdown {
+  days: number;
+  hours: number;
+  minutes: number;
+  seconds: number;
+}
 
 const hrsPerDay = 24;
 
@@ -27,15 +35,34 @@ export const timeMeasurement = {
   msPerDay,
 };
 
-export function msToTime(ms: UtcMilliseconds) {
-  const seconds = Math.floor(ms / msPerSec);
-  const minutes = Math.floor(seconds / secsPerMin);
-  const hours = Math.floor(minutes / minsPerHr);
-
+export function flipTimeSign({
+  days,
+  hours,
+  minutes,
+  seconds,
+}: Time24HourBreakdown) {
   return {
-    days: Math.floor(hours / hrsPerDay),
-    hours: hours % hrsPerDay,
-    minutes: minutes % minsPerHr,
-    seconds: seconds % secsPerMin,
+    days: flipNumberSign(days),
+    hours: flipNumberSign(hours),
+    minutes: flipNumberSign(minutes),
+    seconds: flipNumberSign(seconds),
   };
+}
+
+export function msToTime(ms: UtcMilliseconds): Time24HourBreakdown {
+  const isNegative = Math.sign(ms) === -1;
+  const forcedPositiveMs = Math.abs(ms);
+
+  const totalSeconds = Math.floor(forcedPositiveMs / msPerSec);
+  const totalMinutes = Math.floor(totalSeconds / secsPerMin);
+  const totalHours = Math.floor(totalMinutes / minsPerHr);
+
+  const time = {
+    days: Math.floor(totalHours / hrsPerDay),
+    hours: totalHours % hrsPerDay,
+    minutes: totalMinutes % minsPerHr,
+    seconds: totalSeconds % secsPerMin,
+  };
+
+  return isNegative ? flipTimeSign(time) : time;
 }


### PR DESCRIPTION
This PR finally implements a mechanic to calculate `progress` between intervals.

This works by accepting an optional `onPause()?: void` callback within the hook `options = {}`. The `onPause` callback returns a `IntervalTimeData` object containing `progress` and `timeRemaining`.

Originally, I was expecting to have the `hook` return a `TimeData` object. While there is probably a reliable way to do this... I've had a hard time getting the results I would expect during testing. I think a `callback` pattern is the quickest way to a solution.

Additionally, I have made the following changes:
- Now using `useCallback()` within `useCountdown()`.
- Now correctly handling negative time within `msToTime()`.