### PR TITLE
✨ [useOutsideClick] Introduce `options` arg and merge `exclude` into it

### DIFF
--- a/src/useOutsideClick/index.ts
+++ b/src/useOutsideClick/index.ts
@@ -1,2 +1,6 @@
 export {useOutsideClick} from './useOutsideClick';
-export type {OutsideClickCallback, OutsideClickExclusion} from './types';
+export type {
+  OutsideClickCallback,
+  OutsideClickExclusion,
+  OutsideClickHookOptions,
+} from './types';

--- a/src/useOutsideClick/tests/OutsideClickComponent.tsx
+++ b/src/useOutsideClick/tests/OutsideClickComponent.tsx
@@ -7,12 +7,14 @@ import type {OutsideClickCallback} from '../types';
 export interface OutsideClickComponentProps {
   onAction(): void;
   onOutsideClick: OutsideClickCallback;
+  disabled?: boolean;
   exclude?: boolean;
 }
 
 export function OutsideClickComponent({
   onAction,
   onOutsideClick,
+  disabled = false,
   exclude = false,
 }: OutsideClickComponentProps) {
   const [buttonElement, buttonRef] = useInstantRef<HTMLButtonElement>();
@@ -20,11 +22,12 @@ export function OutsideClickComponent({
   const firstElementRef = useRef<HTMLHeadingElement>(null);
   const lastElementRef = useRef<HTMLParagraphElement>(null);
 
-  useOutsideClick(
-    buttonElement,
-    onOutsideClick,
-    exclude ? [firstElementRef.current, lastElementRef.current] : undefined,
-  );
+  useOutsideClick(buttonElement, onOutsideClick, {
+    disabled,
+    exclude: exclude
+      ? [firstElementRef.current, lastElementRef.current]
+      : undefined,
+  });
 
   return (
     <div className="OutsideClickComponent">

--- a/src/useOutsideClick/tests/useOutsideClick.test.tsx
+++ b/src/useOutsideClick/tests/useOutsideClick.test.tsx
@@ -73,34 +73,76 @@ describe('useOutsideClick', () => {
     });
   });
 
-  describe('exclude', () => {
-    const mockOnAction = vi.fn();
+  describe('options', () => {
+    describe('disabled', () => {
+      const mockOnAction = vi.fn();
 
-    it('will not trigger callback when click matches an excluded element', async () => {
-      const mockOnOutsideClick = vi.fn();
+      it('will not trigger callback when toggled', async () => {
+        const mockOnOutsideClick = vi.fn();
 
-      const {user} = mountWithUser(
-        <OutsideClickComponent
-          exclude
-          onAction={mockOnAction}
-          onOutsideClick={mockOnOutsideClick}
-        />,
-      );
+        const {user, rerender} = mountWithUser(
+          <OutsideClickComponent
+            onAction={mockOnAction}
+            onOutsideClick={mockOnOutsideClick}
+          />,
+        );
 
-      const firstElement = screen.getByText(/first element/i);
-      await user.click(firstElement);
+        const firstElement = screen.getByText(/first element/i);
+        await user.click(firstElement);
+        expect(mockOnOutsideClick).toHaveBeenCalledTimes(1);
 
-      expect(mockOnOutsideClick).not.toHaveBeenCalled();
+        rerender(
+          <OutsideClickComponent
+            disabled
+            onAction={mockOnAction}
+            onOutsideClick={mockOnOutsideClick}
+          />,
+        );
 
-      const lastElement = screen.getByText(/last element/i);
-      await user.click(lastElement);
+        await user.click(firstElement);
+        expect(mockOnOutsideClick).not.toHaveBeenCalledTimes(2);
 
-      expect(mockOnOutsideClick).not.toHaveBeenCalled();
+        rerender(
+          <OutsideClickComponent
+            onAction={mockOnAction}
+            onOutsideClick={mockOnOutsideClick}
+          />,
+        );
 
-      const outsideElement = screen.getByTestId('OutsideElement');
-      await user.click(outsideElement);
+        await user.click(firstElement);
+        expect(mockOnOutsideClick).toHaveBeenCalledTimes(2);
+      });
+    });
 
-      expect(mockOnOutsideClick).toHaveBeenCalledTimes(1);
+    describe('exclude', () => {
+      const mockOnAction = vi.fn();
+
+      it('will not trigger callback when click matches an excluded element', async () => {
+        const mockOnOutsideClick = vi.fn();
+
+        const {user} = mountWithUser(
+          <OutsideClickComponent
+            exclude
+            onAction={mockOnAction}
+            onOutsideClick={mockOnOutsideClick}
+          />,
+        );
+
+        const firstElement = screen.getByText(/first element/i);
+        await user.click(firstElement);
+
+        expect(mockOnOutsideClick).not.toHaveBeenCalled();
+
+        const lastElement = screen.getByText(/last element/i);
+        await user.click(lastElement);
+
+        expect(mockOnOutsideClick).not.toHaveBeenCalled();
+
+        const outsideElement = screen.getByTestId('OutsideElement');
+        await user.click(outsideElement);
+
+        expect(mockOnOutsideClick).toHaveBeenCalledTimes(1);
+      });
     });
   });
 });

--- a/src/useOutsideClick/types.ts
+++ b/src/useOutsideClick/types.ts
@@ -1,2 +1,2 @@
 export type OutsideClickCallback = (event: PointerEvent) => void;
-export type OutsideClickExclusion = (HTMLElement | null)[];
+export type OutsideClickExclusion = (HTMLElement | null | undefined)[];

--- a/src/useOutsideClick/types.ts
+++ b/src/useOutsideClick/types.ts
@@ -1,2 +1,7 @@
 export type OutsideClickCallback = (event: PointerEvent) => void;
 export type OutsideClickExclusion = (HTMLElement | null | undefined)[];
+
+export interface OutsideClickHookOptions {
+  disabled?: boolean;
+  exclude?: OutsideClickExclusion;
+}

--- a/src/useOutsideClick/useOutsideClick.ts
+++ b/src/useOutsideClick/useOutsideClick.ts
@@ -1,14 +1,25 @@
 import {useCallback, useRef} from 'react';
 
+import {filterNullishValuesFromObject} from '../utilities';
 import {useEventListener} from '../useEventListener';
 import {useIsoLayoutEffect} from '../useIsoLayoutEffect';
-import type {OutsideClickCallback, OutsideClickExclusion} from './types';
+import type {OutsideClickCallback, OutsideClickHookOptions} from './types';
+
+const DEFAULT_OPTIONS: Required<OutsideClickHookOptions> = {
+  disabled: false,
+  exclude: [],
+};
 
 export function useOutsideClick(
   element: HTMLElement | null | undefined,
   callback: OutsideClickCallback,
-  exclude: OutsideClickExclusion = [],
+  options?: OutsideClickHookOptions,
 ) {
+  const {disabled, exclude} = {
+    ...DEFAULT_OPTIONS,
+    ...filterNullishValuesFromObject<OutsideClickHookOptions>(options ?? {}),
+  };
+
   const elementRef = useRef(element);
   const callbackRef = useRef(callback);
 
@@ -39,7 +50,7 @@ export function useOutsideClick(
     element?.ownerDocument,
     'click',
     memoizedCallback,
-    {},
+    {disabled},
     {capture: true},
   );
 }


### PR DESCRIPTION
**Resolves:** https://github.com/beefchimi/react-hooks/issues/42

It is helpful to "disable" the `useOutsideClick() > callback` when we don't care about it.

For example, we might have a `input` component that is rendered at all times - therefor rendering the `useOutsideClick()` within the component - but that `callback` is only relevant when the `input` is `:focus`. Otherwise, we end up calling the `callback` whenever the `user` interacts with the `page` outside of the `input`.

Of course, a workaround here is to include a condition within the `callback` to early return. But, since we already get a `disabled` option from `useEventListener()`, we might as well use it.

This PR allows `useOutsideClick()` to pass `disabled` to `useEventListener()` by making the following changes:
- Replace `exclude` argument with `options` object.
- Move `exclude` into the `options` object.
- Introduce `disabled` to the `options` object.