### PR TITLE
✨ [useKeyPress] Improve KeyPressCallback type

### DIFF
--- a/src/useKeyPress/types.ts
+++ b/src/useKeyPress/types.ts
@@ -1,4 +1,4 @@
-import type {GlobalEventCallback, GlobalEventTarget} from '../types';
+import type {GlobalEventTarget} from '../types';
 
 export enum KeyPressEventType {
   Down = 'keydown',
@@ -6,9 +6,7 @@ export enum KeyPressEventType {
   Up = 'keyup',
 }
 
-// TODO: Figure out how to type this for `KeyboardEvent`.
-// TypeScript complains about the `event` type.
-export type KeyPressCallback = GlobalEventCallback;
+export type KeyPressCallback = (event: KeyboardEvent) => void;
 export type KeyPressInput = string[];
 
 // TODO: Consider a `preferKeyCode` boolean option:

--- a/src/useKeyPress/useKeyPress.ts
+++ b/src/useKeyPress/useKeyPress.ts
@@ -30,7 +30,7 @@ export function useKeyPress(
   const callbackRef = useRef(callback);
 
   const handleCallback: KeyPressCallback = useCallback(
-    (event: KeyboardEvent) => {
+    (event) => {
       const requiredKeysEngaged = keys.some((key) => event.key === key);
 
       if (requiredKeysEngaged) {


### PR DESCRIPTION
This PR switches from `event: any` to `event: KeyboardEvent`.

At some point I must have been getting a `TS` error... but that does not appear to be the case anymore.